### PR TITLE
Prune variable

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -71,6 +71,10 @@ app.get( '/plans', function ( req, res, next ){
 });
 
 app.post( '/checkout', function ( req, res, next ){
+  
+  delete plans[ req.body.plan ].TOKEN;
+  delete plans[ req.body.plan ].PAYERID;
+  
   var params = plans[ req.body.plan ];
 
   ec.set( params, function ( err, data ){


### PR DESCRIPTION
The current script holds the old token and payerid in its variable, which result in error if more than one payment is made. (console.log(plans[ req.body.plan ]) in the start of the /checkout route and make two payments, which another is succeeded)

This patch removes those two variables, resulting in working code.
