### PR TITLE
Adding support for "Buyer Pays on PayPal" functionality

### DIFF
--- a/lib/paypal-ec.js
+++ b/lib/paypal-ec.js
@@ -36,6 +36,7 @@ var API_METHODS = [
 var PayPalEC = function ( cred, opts ){
   this.nvpreq  = new NVPRequest( cred, opts );
   this.sandbox = opts ? opts.sandbox : false;
+  this.user_action_commit = opts ? opts.user_action_commit : false;
 };
 
 /**
@@ -56,14 +57,18 @@ PayPalEC.prototype.use_sandbox = function ( bool ){
  * @param {String} token A token responsed from PayPal.
  */
 PayPalEC.prototype.make_payment_url = function ( token ){
+  var queryObj = {
+    cmd   : '_express-checkout',
+    token : token
+  };
+  if(this.user_action_commit) {
+    queryObj.useraction = 'commit';
+  }
   return url.format({
     protocol : 'https:',
     host     : ( this.sandbox ) ? SANDBOX_URL : REGULAR_URL,
     pathname : '/cgi-bin/webscr',
-    query    : {
-      cmd   : '_express-checkout',
-      token : token
-    }
+    query    : queryObj
   });
 };
 


### PR DESCRIPTION
This handles cases where there is no confirmation window on the caller website. by using the `useraction="commit"` query param.
